### PR TITLE
Added multiarch docker images

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,9 @@
 # ads-service-modules
 
+# Local build with dobi
+
+Make sure that you manually run `docker login` for user `ci4rail` on your host system. The `~/.docker/config.json` gets mounted for the build steps in order to push the docker images.
+
 # Build pipeline
 
 Setting the pipeline:
@@ -7,6 +11,8 @@ Setting the pipeline:
 $ fly -t prod set-pipeline -p ads-service-modules -c pipeline.yaml -l ci/config.yaml  -l ci/credentials.yaml
 ```
 
-**Note: the concourse server running the `pipeline.yaml` needs to have the following packages installed:**
+# Build misc informatin
+
+**Note: the host (either locally or concourse CI server) needs to have the following packages installed:**
 - `qemu-user-static`
 - `binfmt-support`

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,12 @@
+# ads-service-modules
+
+# Build pipeline
+
+Setting the pipeline:
+```
+$ fly -t prod set-pipeline -p ads-service-modules -c pipeline.yaml -l ci/config.yaml  -l ci/credentials.yaml
+```
+
+**Note: the concourse server running the `pipeline.yaml` needs to have the following packages installed:**
+- `qemu-user-static`
+- `binfmt-support`

--- a/ads-node-module/Makefile
+++ b/ads-node-module/Makefile
@@ -4,7 +4,7 @@ VERSION ?= $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty)
 GO_LDFLAGS = -ldflags "-X ads-node-module/internal/message/version.Version=$(VERSION)"
 
 build:
-	GOOS=linux GOARCH=arm64 go build $(GO_LDFLAGS) -o ${BIN_DIR}/${NAME} main.go
+	GOOS=linux go build $(GO_LDFLAGS) -o ${BIN_DIR}/${NAME} main.go
 
 test:
 	go test ./...

--- a/ads-node-module/dobi.yaml
+++ b/ads-node-module/dobi.yaml
@@ -36,13 +36,15 @@ job=build-ads-node-module:
     tags:
       - build
 
-image=image-ads-node-module:
-  image: "ci4rail/ads-node-module"
-  context: "ads-node-module"
-  dockerfile: Dockerfile
-  tags:
-    - "{env.GitVersion_BranchVersion}"
-  args:
-    VERSION: "{env.GitVersion_Sha}"
-  annotations:
-    description: "-> build ads-node-module docker image"
+job=build-and-push-image-ads-node-module:
+  use: dind-buildx
+  mounts:
+    - mount-ads-node-module-src
+    - mount-docker-socket
+    - mount-docker-config
+  interactive: true
+  command: sh -c "cd /src;
+           docker buildx build --push --platform linux/arm64,linux/amd64 --tag ci4rail/ads-node-module:${VERSION} ."
+  env:
+   - DOCKER_DRIVER=overlay2
+   - VERSION={env.GitVersion_BranchVersion}

--- a/ads-node-module/dobi.yaml
+++ b/ads-node-module/dobi.yaml
@@ -44,7 +44,10 @@ job=build-and-push-image-ads-node-module:
     - mount-docker-config
   interactive: true
   command: sh -c "cd /src;
-           docker buildx build --push --platform linux/arm64,linux/amd64 --tag ci4rail/ads-node-module:${VERSION} ."
+           name=$(docker buildx create --use);
+           docker buildx build --push --platform linux/arm64,linux/amd64 --tag ci4rail/ads-node-module:${VERSION} .;
+           docker kill buildx_buildkit_${name}0;
+           docker rm buildx_buildkit_${name}0"
   env:
    - DOCKER_DRIVER=overlay2
    - VERSION={env.GitVersion_BranchVersion}

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -12,6 +12,15 @@ mount=mount-go-pkg:
   path: "/go/pkg"
   read-only: false
 
+mount=mount-docker-config:
+  bind: "~/.docker"
+  path: "/root/.docker"
+  read-only: false
+
+mount=mount-docker-socket:
+  bind: "/var/run/docker.sock"
+  path: "/var/run/docker.sock"
+  read-only: false
 
 # ===================================================
 # images
@@ -21,3 +30,9 @@ image=image-go-builder:
   pull: once
   tags:
     - 1.16-buster
+
+image=dind-buildx:
+  image: jdrouet/docker-with-buildx
+  pull: once
+  tags:
+    - stable

--- a/meta.yaml
+++ b/meta.yaml
@@ -15,16 +15,8 @@ meta:
 alias=build:
   tasks:
     - build-ads-node-module
-    - image-ads-node-module
+    - build-and-push-image-ads-node-module
   annotations:
-    description: "[alias] build all"
-    tags:
-      - alias
-
-alias=deploy:
-  tasks:
-    - image-ads-node-module:push
-  annotations:
-    description: "[alias] push all"
+    description: "[alias] build (and push) all"
     tags:
       - alias

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,3 +1,11 @@
+resource_types:
+  - name: docker-buildx
+    type: docker-image
+    privileged: true
+    source:
+      repository: starkandwayne/docker-buildx-resource
+      tag: edge
+
 resources:
   # Upstream docker images
   - name: image-bb-gitversion-tool
@@ -22,7 +30,7 @@ resources:
 
   # Own docker images
   - name: image-ads-node-module
-    type: docker-image
+    type: docker-buildx
     source:
       repository: ci4rail/ads-node-module
       username: ((registry_user))
@@ -73,10 +81,11 @@ jobs:
                 ROOT=$(pwd)
                 echo {\"VERSION\":\"$(cat gitversion/plain/Sha)\"} > build-args/build-args
 
+
       - put: image-ads-node-module
         params:
           build: source/ads-node-module/
-          dockerfile: source/ads-node-module/Dockerfile
+          buildx_platforms: "linux/amd64,linux/arm64"
+          build_args_file: build-args/build-args
           latest: false
           tag_file: gitversion/plain/InformationalVersion
-          build_args_file: build-args/build-args

--- a/version.yaml
+++ b/version.yaml
@@ -3,7 +3,7 @@
 # ===================================================
 
 mount=mount-gitversion-source-dir:
-  bind: "{fs.projectdir}"
+  bind: "."
   path: /git
   read-only: false # needs to be read/write to work correctly!
 


### PR DESCRIPTION
This PR adds an amd64 and arm64 docker image.
To verify that both the image and the containing binary has the correct architecture, one can pull the image for a specific architecture, extract the layers and see what's inside.

```
#!/bin/bash
IMAGE=ci4rail/ads-node-module:0.1.0-2.Branch.feature-multiarch-docker.Sha.0da2bd3eda6fb3933ae7734b7e85ead5d4043897
for arch in amd64 arm64
do
  mkdir -p /tmp/${arch}
  cd /tmp/${arch}
  docker pull --platform ${arch} ${IMAGE} > /dev/null 2>&1
  docker save ${IMAGE} -o /tmp/${arch}/image.tar > /dev/null 2>&1
  tar xf image.tar > /dev/null 2>&1
  cd $(ls -d -- */)
  tar xf layer.tar > /dev/null 2>&1
  echo "content from ${arch} image"
  file ads-node-module
  cd /tmp && rm -rf /tmp/${arch}
done
```

The output shows that the ads-node-module binaries match the pulled docker images architecture.
```
./test.sh   
content from amd64 image
ads-node-module: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=Kl3Imh65w7qVZK_4tbRQ/aqmi0X-moSy9s_dHSSFo/LGUAkbXB5n2NLicbhvZr/ejpySAkD_92knixY8olU, not stripped
content from arm64 image
ads-node-module: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=9hgUHAbIJH9Fu2_zAm7e/B5Ha5cGwuqKDjOzPGqYM/lFwpzdu08Wn93RWVFKJH/O0VF_4u_ilJuyTsd3C-S, not stripped
```

The dobi scripts for building locally will build and push directly. A separation of build and push is not possible for technical reasons regarding docker images that can't have multiarch manifests locally.